### PR TITLE
Feature / Limit the number of scores in the feed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,6 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
-  x86_64-darwin-24
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -254,4 +253,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.5.23
+   2.2.15

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-24
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -253,4 +254,4 @@ RUBY VERSION
    ruby 3.0.1p64
 
 BUNDLED WITH
-   2.2.15
+   2.5.23

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,20 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should allow only 25 scores to appear' do
+      30.times do
+        create(:score, user: @user1, total_score: 80, played_at: '2021-06-20')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: https://github.com/AACraiu/golfr_backend/issues/21

**Changes**

Added a limit of 25 to return the most recent scores and a corresponding test.

**Before**

<img width="733" height="266" alt="Screenshot 2025-07-23 at 15 17 42" src="https://github.com/user-attachments/assets/4ca7a14f-177f-4167-8bf2-c308afc7767d" />
<img width="840" height="645" alt="Screenshot 2025-07-24 at 10 28 26" src="https://github.com/user-attachments/assets/4b57b955-10f5-4921-a322-29eed5670fc6" />

**After**

<img width="466" height="68" alt="Finished in 1 02 seconds (files took 8 55 seconds to load)" src="https://github.com/user-attachments/assets/d8d59970-fc7a-4c1d-ac50-f69327dffa52" />
<img width="841" height="637" alt="Scripts" src="https://github.com/user-attachments/assets/273db09a-bd46-497f-952b-991665cbf034" />

